### PR TITLE
Fix Typo for documentation of the helper module

### DIFF
--- a/pleco/src/helper/mod.rs
+++ b/pleco/src/helper/mod.rs
@@ -1,6 +1,6 @@
 //! Statically initialized lookup tables.
 //!
-//! Whenever a `Board` is created, these are also created as well. Calling `Hepler::new()` will
+//! Whenever a `Board` is created, these are also created as well. Calling `Helper::new()` will
 //! initialize the tables the first time it's called, and successive calls won't waste time
 //! initializing the table.
 //!


### PR DESCRIPTION
https://github.com/sfleischman105/Pleco/blob/master/pleco/src/helper/mod.rs#L3

Should be `Calling Helper::new()` instead of `Calling Hepler::new()` :)