### PR TITLE
update the feature

### DIFF
--- a/pleco_engine/src/lib.rs
+++ b/pleco_engine/src/lib.rs
@@ -21,7 +21,7 @@
 #![feature(test)]
 #![feature(allocator_api)]
 #![feature(trusted_len)]
-#![feature(const_fn)]
+#![feature(const_mut_refs)]
 #![feature(alloc_layout_extra)]
 #![feature(thread_spawn_unchecked)]
 


### PR DESCRIPTION
The feature `#![feature(const_fn)]` doesn't work any more.
It has been explained [in this issue](https://github.com/rust-lang/rust/issues/77134#issuecomment-698111568) how to solve it.
This PR simply updates the feature.