### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ board.undo_move();
 assert_eq!(board.moves_played(),0);
 ```
 
-For more informaton about `pleco` as a library, see the [pleco README.md](https://github.com/sfleischman105/Pleco/tree/main/pleco).
+For more information about `pleco` as a library, see the [pleco README.md](https://github.com/sfleischman105/Pleco/tree/main/pleco).
 
 ## Contributing
 

--- a/pleco/src/board/fen.rs
+++ b/pleco/src/board/fen.rs
@@ -103,7 +103,7 @@ lazy_static! {
 pub fn is_valid_fen(board: Board) -> Result<Board, FenBuildError> {
     let checks = board.checkers();
     let num_checks = checks.count_bits();
-    // Cant be more than 2 checking pieces at a time
+    // Can't be more than 2 checking pieces at a time
     if num_checks > 2 {
         return Err(FenBuildError::IllegalNumCheckingPieces { num: num_checks });
     }

--- a/pleco/src/board/mod.rs
+++ b/pleco/src/board/mod.rs
@@ -159,7 +159,7 @@ impl PreFetchable for PreFetchDummy {
 /// by both Engines and Players / Bots alike.
 ///
 /// Ideally, the Engine contains the original Representation of a board (owns the board), and utilizes
-/// `Board::shallow_clone()` to share this representaion with Players.
+/// `Board::shallow_clone()` to share this representation with Players.
 ///
 /// # Examples
 ///
@@ -406,7 +406,7 @@ impl Board {
     ///
     /// The FEN string must be valid, or else the method will return an Error.
     ///
-    /// There is a possibility of the FEN string representing an unvalid position, with no panics resulting.
+    /// There is a possibility of the FEN string representing an invalid position, with no panics resulting.
     /// The Constructed Board may have some Undefined Behavior as a result. It is up to the user to give a
     /// valid FEN string.
     pub fn from_fen(fen: &str) -> Result<Board, FenBuildError> {
@@ -532,7 +532,7 @@ impl Board {
         };
 
         // Total Moves Played
-        // Moves is defined as everytime White moves, so gotta translate to total moves
+        // Moves is defined as every time White moves, so gotta translate to total moves
         let mut total_moves = if det_split.len() >= 6 && det_split[5] != "-" {
             (det_split[5].parse::<u16>()? - 1) * 2
         } else {
@@ -576,7 +576,7 @@ impl Board {
     /// assert_eq!(board.fen(),"rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
     /// ```
     pub fn fen(&self) -> String {
-        // TODO: Doesnt display if rank 8 has zero pieces on it
+        // TODO: Doesn't display if rank 8 has zero pieces on it
         let mut s = String::default();
 
         for reverse_rnk in 0..8 {
@@ -699,7 +699,7 @@ impl Board {
         // New Arc for the board to have by making a partial clone of the current state
         let mut next_arc_state = UniqueArc::new(self.state.partial_clone());
 
-        // Seperate Block to allow derefencing the BoardState
+        // Separate Block to allow dereferencing the BoardState
         // As there is garunteed only one owner of the Arc, this is allowed
         {
             let new_state: &mut BoardState = &mut next_arc_state;
@@ -2001,7 +2001,7 @@ impl Board {
 
     /// Returns if a move is a capture.
     ///
-    /// This is similar to `BitMove::is_capture`, but instead comapres the move to the `Board`s
+    /// This is similar to `BitMove::is_capture`, but instead compares the move to the `Board`s
     /// data, rather than relying on the information encoded in the move.
     #[inline(always)]
     pub fn is_capture(&self, mov: BitMove) -> bool {
@@ -2012,7 +2012,7 @@ impl Board {
 
     /// Returns if a move is a capture.
     ///
-    /// This is similar to `BitMove::is_capture` & `BitMove::is_promo`, but instead comapres the
+    /// This is similar to `BitMove::is_capture` & `BitMove::is_promo`, but instead compares the
     /// move to the `Board`s data, rather than relying on the information encoded in the move.
     #[inline(always)]
     pub fn is_capture_or_promotion(&self, mov: BitMove) -> bool {
@@ -2381,7 +2381,7 @@ impl Board {
 
     /// Print the board alongside useful information.
     ///
-    /// Mostly for Debugging useage.
+    /// Mostly for Debugging usage.
     pub fn fancy_print(&self) {
         self.pretty_print();
         println!(

--- a/pleco/src/board/movegen.rs
+++ b/pleco/src/board/movegen.rs
@@ -339,7 +339,7 @@ where
         // Possible king moves, Where the king cannot move into a slider / own pieces
         let k_moves: BitBoard = king_moves(ksq) & !slider_attacks & !self.us_occ;
 
-        // Seperate captures and non captures
+        // Separate captures and non captures
         let mut captures_bb: BitBoard = k_moves & self.them_occ;
         let mut non_captures_bb: BitBoard = k_moves & !self.them_occ;
         self.move_append_from_bb_flag::<L>(&mut captures_bb, ksq, BitMove::FLAG_CAPTURE);
@@ -449,7 +449,7 @@ where
 
         let mut empty_squares = BitBoard(0);
 
-        // seperate these two for promotion moves and non promotions
+        // separate these two for promotion moves and non promotions
         let pawns_rank_7: BitBoard = all_pawns & rank_7;
         let pawns_not_rank_7: BitBoard = all_pawns & !rank_7;
 

--- a/pleco/src/core/mod.rs
+++ b/pleco/src/core/mod.rs
@@ -605,7 +605,7 @@ impl fmt::Debug for Piece {
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Debug, Ord, PartialOrd, Eq)]
 pub enum File {
-    A = 0, // eg a specific coloumn
+    A = 0, // eg a specific column
     B = 1,
     C = 2,
     D = 3,

--- a/pleco/src/core/piece_move.rs
+++ b/pleco/src/core/piece_move.rs
@@ -258,7 +258,7 @@ impl BitMove {
     ///
     /// # Safety
     ///
-    /// A Null move is never a valid move to play. Using a Null move should onl be used for search and
+    /// A Null move is never a valid move to play. Using a Null move should only be used for search and
     /// evaluation purposes.
     #[inline]
     pub const fn null() -> Self {

--- a/pleco/src/core/sq.rs
+++ b/pleco/src/core/sq.rs
@@ -74,7 +74,7 @@ impl_bit_ops!(SQ, u8);
 pub const NO_SQ: SQ = SQ(64);
 
 impl SQ {
-    /// A square that isn't on the board. Basically equivilant to `Option<SQ>` where the value is
+    /// A square that isn't on the board. Basically equivalent to `Option<SQ>` where the value is
     /// `None`.
     pub const NONE: SQ = NO_SQ;
 

--- a/pleco/src/helper/boards.rs
+++ b/pleco/src/helper/boards.rs
@@ -142,7 +142,7 @@ pub fn forward_rank_bb(player: Player, rank: Rank) -> u64 {
 ///
 /// # Safety
 ///
-/// The Square must be within normal bounds, or else a panic or undefined behvaior may occur.
+/// The Square must be within normal bounds, or else a panic or undefined behaviour may occur.
 #[inline(always)]
 pub fn pawn_attacks_span(player: Player, sq: SQ) -> u64 {
     debug_assert!(sq.is_okay());
@@ -157,7 +157,7 @@ pub fn pawn_attacks_span(player: Player, sq: SQ) -> u64 {
 ///
 /// # Safety
 ///
-/// The Square must be within normal bounds, or else a panic or undefined behvaior may occur.
+/// The Square must be within normal bounds, or else a panic or undefined behaviour may occur.
 #[inline(always)]
 pub fn forward_file_bb(player: Player, sq: SQ) -> u64 {
     debug_assert!(sq.is_okay());
@@ -172,7 +172,7 @@ pub fn forward_file_bb(player: Player, sq: SQ) -> u64 {
 /// "passed pawn".
 /// # Safety
 ///
-/// The Square must be within normal bounds, or else a panic or undefined behvaior may occur.
+/// The Square must be within normal bounds, or else a panic or undefined behaviour may occur.
 #[inline(always)]
 pub fn passed_pawn_mask(player: Player, sq: SQ) -> u64 {
     debug_assert!(sq.is_okay());

--- a/pleco/src/helper/magic.rs
+++ b/pleco/src/helper/magic.rs
@@ -125,7 +125,7 @@ unsafe fn gen_magic_board(
     static_magics: *mut SMagic,
     attacks: *mut u64,
 ) {
-    // Creates PreSMagic to hold raw numbers. Technically jsut adds room to stack
+    // Creates PreSMagic to hold raw numbers. Technically just adds room to stack
     let mut pre_sq_table: [PreSMagic; 64] = PreSMagic::init64();
 
     // Initializes each PreSMagic
@@ -158,7 +158,7 @@ unsafe fn gen_magic_board(
         // Magic number for later
         let mut magic: u64;
 
-        // edges is the bitboard represenation of the edges s is not on.
+        // edges is the bitboard representation of the edges s is not on.
         // e.g. sq A1 is on FileA and Rank1, so edges = bitboard of FileH and Rank8
         // mask = occupancy mask of square s
         let edges: u64 = ((RANK_1 | RANK_8) & !rank_bb(s)) | ((FILE_A | FILE_H) & !file_bb(s));

--- a/pleco/src/helper/mod.rs
+++ b/pleco/src/helper/mod.rs
@@ -1,13 +1,13 @@
 //! Statically initialized lookup tables.
 //!
-//! Whenever a `Board` is created, these are also created as well. Calling `Hepler::new()` will
+//! Whenever a `Board` is created, these are also created as well. Calling `Helper::new()` will
 //! initialize the tables the first time it's called, and successive calls won't waste time
 //! initializing the table.
 //!
 //! It is highly recommended to go through a `Helper` to access these tables, as the access will
 //! guarantee that the tables are initialized in the first place.
 //!
-//! If you want the same functions, but can ensure the Tables are initalized, see [`helper::prelude`]
+//! If you want the same functions, but can ensure the Tables are initialized, see [`helper::prelude`]
 //! for those raw functions.
 //!
 //! [`helper::prelude`]: prelude/index.html
@@ -152,7 +152,7 @@ impl Helper {
     ///
     /// # Safety
     ///
-    /// The Square must be within normal bounds, or else a panic or undefined behvaior may occur.
+    /// The Square must be within normal bounds, or else a panic or undefined behaviour may occur.
     #[inline(always)]
     pub fn pawn_attacks_span(self, player: Player, sq: SQ) -> BitBoard {
         prelude::pawn_attacks_span(player, sq)
@@ -162,7 +162,7 @@ impl Helper {
     ///
     /// # Safety
     ///
-    /// The Square must be within normal bounds, or else a panic or undefined behvaior may occur.
+    /// The Square must be within normal bounds, or else a panic or undefined behaviour may occur.
     #[inline(always)]
     pub fn forward_file_bb(self, player: Player, sq: SQ) -> BitBoard {
         prelude::forward_file_bb(player, sq)
@@ -173,7 +173,7 @@ impl Helper {
     ///
     /// # Safety
     ///
-    /// The Square must be within normal bounds, or else a panic or undefined behvaior may occur.
+    /// The Square must be within normal bounds, or else a panic or undefined behaviour may occur.
     #[inline(always)]
     pub fn passed_pawn_mask(self, player: Player, sq: SQ) -> BitBoard {
         prelude::passed_pawn_mask(player, sq)

--- a/pleco/src/helper/prelude.rs
+++ b/pleco/src/helper/prelude.rs
@@ -153,7 +153,7 @@ pub fn forward_rank_bb(player: Player, rank: Rank) -> BitBoard {
 ///
 /// # Safety
 ///
-/// The Square must be within normal bounds, or else a panic or undefined behvaior may occur.
+/// The Square must be within normal bounds, or else a panic or undefined behaviour may occur.
 #[inline(always)]
 pub fn pawn_attacks_span(player: Player, sq: SQ) -> BitBoard {
     BitBoard(boards::pawn_attacks_span(player, sq))
@@ -163,7 +163,7 @@ pub fn pawn_attacks_span(player: Player, sq: SQ) -> BitBoard {
 ///
 /// # Safety
 ///
-/// The Square must be within normal bounds, or else a panic or undefined behvaior may occur.
+/// The Square must be within normal bounds, or else a panic or undefined behaviour may occur.
 #[inline(always)]
 pub fn forward_file_bb(player: Player, sq: SQ) -> BitBoard {
     BitBoard(boards::forward_file_bb(player, sq))
@@ -173,7 +173,7 @@ pub fn forward_file_bb(player: Player, sq: SQ) -> BitBoard {
 /// "passed pawn".
 /// # Safety
 ///
-/// The Square must be within normal bounds, or else a panic or undefined behvaior may occur.
+/// The Square must be within normal bounds, or else a panic or undefined behaviour may occur.
 #[inline(always)]
 pub fn passed_pawn_mask(player: Player, sq: SQ) -> BitBoard {
     BitBoard(boards::passed_pawn_mask(player, sq))

--- a/pleco/src/tools/eval.rs
+++ b/pleco/src/tools/eval.rs
@@ -45,7 +45,7 @@ fn flatten(arr: [[i32; FILE_CNT]; RANK_CNT]) -> [i32; SQ_CNT] {
 }
 
 /// A simple evaluation structure. This is included as an example, and shouldn't
-/// neccessarily be used inside serious chess engines.
+/// necessarily be used inside serious chess engines.
 ///
 /// ```
 /// use pleco::tools::eval::Eval;

--- a/pleco/src/tools/pleco_arc.rs
+++ b/pleco/src/tools/pleco_arc.rs
@@ -50,7 +50,7 @@ impl<T> DerefMut for UniqueArc<T> {
     }
 }
 
-/// Reference counting pointer, sharable between threads.
+/// Reference counting pointer, shareable between threads.
 pub struct Arc<T: ?Sized> {
     p: NonNull<ArcInner<T>>,
 }

--- a/pleco/src/tools/tt.rs
+++ b/pleco/src/tools/tt.rs
@@ -359,7 +359,7 @@ impl TranspositionTable {
     /// Probes the Transposition Table for a specified Key. Returns (true, entry) if either (1) an
     /// Entry corresponding to the current key is found, or an Open Entry slot is found for the key.
     /// In the case of an open Entry, the entry can be tested for its contents by using `Entry::is_empty()`.
-    /// If no entry is found && there are no open entries, returns the entry that is is most irrelevent to
+    /// If no entry is found && there are no open entries, returns the entry that is is most irrelevant to
     /// the current search, e.g. has the shallowest depth or was found in a previous search.
     ///
     /// If 'true' is returned, the Entry is guaranteed to have the correct time.

--- a/pleco_engine/src/consts.rs
+++ b/pleco_engine/src/consts.rs
@@ -31,7 +31,7 @@ type DummyTimeManager = [u8; TIMER_ALLOC_SIZE];
 
 pub static USE_STDOUT: AtomicBool = AtomicBool::new(true);
 
-static INITALIZED: Once = Once::new();
+static INITIALIZED: Once = Once::new();
 
 /// Global Transposition Table
 static mut TT_TABLE: DummyTranspositionTable = [0; TT_ALLOC_SIZE];
@@ -41,7 +41,7 @@ static mut TIMER: DummyTimeManager = [0; TIMER_ALLOC_SIZE];
 
 #[cold]
 pub fn init_globals() {
-    INITALIZED.call_once(|| {
+    INITIALIZED.call_once(|| {
         prelude::init_statics(); // Initialize static tables
         compiler_fence(Ordering::SeqCst);
         init_tt(); // Transposition Table

--- a/pleco_engine/src/root_moves/root_moves_list.rs
+++ b/pleco_engine/src/root_moves/root_moves_list.rs
@@ -73,7 +73,7 @@ impl RootMoveList {
     ///
     /// # Safety
     ///
-    /// May return a nonsense `RootMove` if the list hasn't been initalized since the start.
+    /// May return a nonsense `RootMove` if the list hasn't been initialized since the start.
     #[inline]
     pub fn first(&mut self) -> &mut RootMove {
         unsafe { self.get_unchecked_mut(0) }

--- a/pleco_engine/src/search/mod.rs
+++ b/pleco_engine/src/search/mod.rs
@@ -120,7 +120,7 @@ impl ThreadStack {
         unsafe { mem::zeroed() }
     }
 
-    /// Get's a certain frame from the stack.
+    /// Gets a certain frame from the stack.
     ///
     /// Assumes the frame is within bounds, otherwise undefined behavior.
     pub fn get(&mut self, frame: usize) -> &mut Stack {
@@ -376,7 +376,7 @@ impl Searcher {
                     break 'aspiration_window;
                 }
 
-                // Order root moves by the score retreived post search.
+                // Order root moves by the score retrieved post search.
 
                 if self.use_stdout()
                     && self.main_thread()
@@ -972,7 +972,7 @@ impl Searcher {
                 }
             }
 
-            // If best_move wasnt found, add it to the list of quiets / captures that failed
+            // If best_move wasn't found, add it to the list of quiets / captures that failed
             if mov != best_move {
                 if capture_or_promotion && captures_count < 32 {
                     captures_searched[captures_count] = mov;
@@ -1218,7 +1218,7 @@ impl Searcher {
                 && best_value > MATED_IN_MAX_PLY
                 && !self.board.is_capture(mov);
 
-            // Don't search moves that lead to a negative static exhange
+            // Don't search moves that lead to a negative static exchange
             if (!in_check || evasion_prunable) && !self.board.see_ge(mov, 0) {
                 continue;
             }

--- a/pleco_engine/src/tables/pawn_table.rs
+++ b/pleco_engine/src/tables/pawn_table.rs
@@ -89,7 +89,7 @@ const STORM_DANGER: [[[Value; RANK_CNT]; 4]; 4] = [
 
 pub static mut CONNECTED: [[[[Score; RANK_CNT]; 3]; 2]; 2] = [[[[Score(0, 0); RANK_CNT]; 3]; 2]; 2];
 
-/// Initalizes the CONNECTED table.
+/// Initializes the CONNECTED table.
 #[cold]
 pub fn init() {
     unsafe {
@@ -268,7 +268,7 @@ impl PawnEntry {
         self.weak_unopposed[player as usize]
     }
 
-    /// Assymetric score of a position.
+    /// Asymmetric score of a position.
     #[inline(always)]
     pub fn asymmetry(&self) -> i16 {
         self.asymmetry

--- a/pleco_engine/src/threadpool/mod.rs
+++ b/pleco_engine/src/threadpool/mod.rs
@@ -28,7 +28,7 @@ type DummyThreadPool = [u8; POOL_SIZE];
 
 // The Global threadpool! Yes, this is *technically* an array the same
 // size as a ThreadPool object. This is a cheap hack to get a global value, as
-// Rust isn't particularily fond of mutable global statics.
+// Rust isn't particularly fond of mutable global statics.
 pub static mut THREADPOOL: DummyThreadPool = [0; POOL_SIZE];
 
 // ONCE for the Threadpool

--- a/pleco_engine/src/uci/options.rs
+++ b/pleco_engine/src/uci/options.rs
@@ -105,7 +105,7 @@ impl OptionsMap {
 // "option name Style type combo default Normal var Solid var Normal var Risky\n"
 // "option name Clear Hash type button\n"
 
-/// UCI complient options for a searcher.
+/// UCI compliant options for a searcher.
 pub trait UCIOption {
     // Returns the type of option. This can be one of the following: button, check, spin, text, or combo.
     fn option_type(&self) -> &'static str;


### PR DESCRIPTION
Found via `codespell -S target -L crate,statics` and `typos --format brief`.